### PR TITLE
Drop railway support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ Button : If you are deploying from a fork
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
-Button : If you are deploying and using Railway
-
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template?template=https%3A%2F%2Fgithub.com%2FPrajjwalDatir%2FKaoi%2F&envs=PREFIX%2CSESSION%2CMODS%2CCRON%2CMONGO_URI%2CGOOGLE_API_KEY%2CCHAT_BOT_URL&optionalEnvs=MODS%2CCRON%2CGOOGLE_API_KEY%2CCHAT_BOT_URL&PREFIXDesc=Prefix+of+your+bot&SESSIONDesc=A+string+for+the+session+to+be+classified+and+to+get+access+to+the+server+endpoints&MODSDesc=The+phone+numbers+of+the+users+who+you+want+to+be+admin+for+the+bot+%28should+be+in+international+format+without+%2B+and+multiple+numbers+must+be+separated+by+a+comma+%5C%22%2C%5C%22%29&CRONDesc=Cron+string+to+clear+chats+in+a+cycle&MONGO_URIDesc=A+secret+String+for+Mongodb+Connection+%28Required%29&GOOGLE_API_KEYDesc=Google+API+key+for+Google+searches+for+MODS+%28Not+Required%29&CHAT_BOT_URLDesc=BrainShop+API+Brain+url)
-
 Use any one of the above to deploy
 
 </div><br/>


### PR DESCRIPTION
I have dropped Railway support because you can't deploy Kaoi on Railway as it uses some dependencies which are banned by Railway